### PR TITLE
Nix build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
-/target
 .idea
 stats.toml
+
+# Build paths
+result
+/target

--- a/README.md
+++ b/README.md
@@ -2,17 +2,47 @@
 
 A TUI based [alternative](https://thealternative.ch) to [MonkeyType](https://monkeytype.com) written in rust.
 
+## Installation
+
+### Cargo
+
+Simply type
+
+```sh
+cargo install crabtype
+```
+
+### Nix
+
+To build CrabType for nix just add this derivation to your nix config
+
+```nix
+    rustapple = pkgs.callPackage (pkgs.fetchFromGitHub {
+        owner = "einsJannis";
+        repo = "CrabType";
+        rev = "<Git Revision>";
+        sha256 = "<Git SHA>";
+    }) {};
+```
+
+You can figure out the revision and the sha265 by running the application `nix-prefetch-git`
+
 ## Run
 
 ```sh
 crabtype [options...]
 ```
+
 ### Options
+
 ```
 -g|--gamemode <file>
 ```
+
 Changes the game mode to the one defined in `<file>`. This file must contain each possible text, separated by newlines.
+
 ```
 -u|--user <file>
 ```
+
 Sets the user file to `<file>`, which is the file which stores the stats in a TOML format.

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,13 @@
+{pkgs ? import <nixpkgs> {}}: let
+  manifest = (pkgs.lib.importTOML ./Cargo.toml).package;
+in
+  pkgs.rustPlatform.buildRustPackage {
+    pname = manifest.name;
+    version = manifest.version;
+    cargoLock.lockFile = ./Cargo.lock;
+    src = pkgs.lib.cleanSource ./.;
+    nativeBuildInputs = [
+    ];
+    buildInputs = [
+    ];
+  }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,10 @@
+let
+  pkgs = import <nixpkgs> {};
+in
+  pkgs.mkShell {
+    name = "crabtype";
+    nativeBuildInputs = [
+    ];
+    buildInputs = [
+    ];
+  }


### PR DESCRIPTION
I added a Nix build script `defaults.nix` and a nix development environment `shell.nix` to Crabtype. Now, one can add Crabtype to their Nix config and install the app natively.